### PR TITLE
Add support for adding new npm packages BEN-1072

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -30,27 +30,27 @@ export async function POST(request: NextRequest) {
         const generatedFiles = await generateApp(description);
 
         // Repair the generated code using Benchify's API
-        const { data } = await benchify.fixer.run({
-            files: generatedFiles.map(file => ({
-                path: file.path,
-                contents: file.content
-            }))
-        });
+        // const { data } = await benchify.fixer.run({
+        //     files: generatedFiles.map(file => ({
+        //         path: file.path,
+        //         contents: file.content
+        //     }))
+        // });
 
         let repairedFiles = generatedFiles;
-        if (data) {
-            const { success, diff } = data;
+        // if (data) {
+        //     const { success, diff } = data;
 
-            if (success && diff) {
-                repairedFiles = generatedFiles.map(file => {
-                    const patchResult = applyPatch(file.content, diff);
-                    return {
-                        ...file,
-                        content: typeof patchResult === 'string' ? patchResult : file.content
-                    };
-                });
-            }
-        }
+        //     if (success && diff) {
+        //         repairedFiles = generatedFiles.map(file => {
+        //             const patchResult = applyPatch(file.content, diff);
+        //             return {
+        //                 ...file,
+        //                 content: typeof patchResult === 'string' ? patchResult : file.content
+        //             };
+        //         });
+        //     }
+        // }
 
         const { sbxId, template, url, allFiles } = await createSandbox({ files: repairedFiles });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2828,9 +2828,9 @@
       "license": "MIT"
     },
     "node_modules/benchify": {
-      "version": "0.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/benchify/-/benchify-0.1.0-alpha.3.tgz",
-      "integrity": "sha512-YNDExmrgJFyeJBZGXhg732+Ikea9fknWWEdMP8A3d1yyYu6LyKRRZSJUzhpPvkiRoDqZVS8kpx+gwlGCmpLfWg==",
+      "version": "0.1.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/benchify/-/benchify-0.1.0-alpha.5.tgz",
+      "integrity": "sha512-UE3gWCwRiN5KIX2gf8nNcx+g68onp/l7Q3zz3YwOK0583TFWdeZ9au387+cSd8UH36ROxzePxEJNiG5jj8YDbg==",
       "license": "Apache-2.0"
     },
     "node_modules/body-parser": {


### PR DESCRIPTION
### TL;DR

Disabled code repair functionality and added automatic dependency installation for user-generated apps.

### What changed?

- Commented out the Benchify code repair functionality in the generate route
- Added a new feature to automatically detect and install new dependencies from the generated package.json
- Implemented `extractNewPackages` function to identify dependencies not included in the base template
- Updated the Benchify package from version 0.1.0-alpha.3 to 0.1.0-alpha.5

### How to test?

1. Generate an app that requires dependencies not in the base template
2. Verify that the console logs show the new packages being installed
3. Confirm the sandbox loads correctly with the new dependencies available
4. Check that the app functions properly without the code repair step

### Why make this change?

The code repair functionality may have been causing issues or was not needed at this stage of development. More importantly, the automatic dependency installation feature improves the user experience by ensuring that all required packages are available in the sandbox environment without manual intervention. This allows generated apps to use a wider range of dependencies while maintaining a lightweight base template.