### PR TITLE
update content to be contents BEN-1528

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -4,8 +4,6 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ChatInterface } from '@/components/ui-builder/chat-interface';
 import { PreviewCard } from '@/components/ui-builder/preview-card';
-import { benchifyFileSchema } from '@/lib/schemas';
-import { z } from 'zod';
 import { generateApp, GenerateAppResult } from '@/lib/actions/generate-app';
 
 // Extract the success type from the union

--- a/components/ui-builder/code-editor.tsx
+++ b/components/ui-builder/code-editor.tsx
@@ -27,7 +27,7 @@ interface FileNode {
     path: string;
     type: 'file' | 'folder';
     children?: FileNode[];
-    content?: string;
+    contents?: string;
 }
 
 export function CodeEditor({ files = [] }: CodeEditorProps) {
@@ -35,7 +35,7 @@ export function CodeEditor({ files = [] }: CodeEditorProps) {
     const [openFolders, setOpenFolders] = useState<Set<string>>(new Set());
 
     // Build file tree structure (pure function, no side effects)
-    const buildFileTree = useCallback((files: Array<{ path: string; content: string }>): { tree: FileNode[], allFolders: string[] } => {
+    const buildFileTree = useCallback((files: Array<{ path: string; contents: string }>): { tree: FileNode[], allFolders: string[] } => {
         const root: FileNode[] = [];
         const folderMap = new Map<string, FileNode>();
         const allFolders: string[] = [];
@@ -59,7 +59,7 @@ export function CodeEditor({ files = [] }: CodeEditorProps) {
                         name: part,
                         path: file.path,
                         type: 'file',
-                        content: file.content
+                        contents: file.contents
                     });
                 } else {
                     // It's a folder
@@ -238,7 +238,7 @@ export function CodeEditor({ files = [] }: CodeEditorProps) {
                                 </pre>
                             )}
                         >
-                            {selectedFile.content}
+                            {selectedFile.contents}
                         </SyntaxHighlighter>
                     </div>
                 ) : (

--- a/components/ui-builder/error-display.tsx
+++ b/components/ui-builder/error-display.tsx
@@ -9,7 +9,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { benchifyFileSchema } from '@/lib/schemas';
 import { z } from 'zod';
 import { generateApp } from '@/lib/actions/generate-app';
-import { runBenchifyFixer, type BenchifyFixerResult } from '@/lib/actions/benchify-fixer';
+import { runBenchifyFixer } from '@/lib/actions/benchify-fixer';
 
 interface BuildError {
     type: 'typescript' | 'build' | 'runtime';

--- a/components/ui-builder/preview-card.tsx
+++ b/components/ui-builder/preview-card.tsx
@@ -46,12 +46,12 @@ interface BuildError {
 }
 
 interface FixResult {
-    originalFiles: z.infer<typeof benchifyFileSchema>;
-    repairedFiles: z.infer<typeof benchifyFileSchema>;
+    originalFiles?: z.infer<typeof benchifyFileSchema>;
+    repairedFiles?: z.infer<typeof benchifyFileSchema>;
     buildOutput: string;
     previewUrl: string;
     buildErrors?: BuildError[];
-    hasErrors: boolean;
+    hasErrors?: boolean;
     editInstruction?: string;
 }
 

--- a/lib/actions/generate-app.ts
+++ b/lib/actions/generate-app.ts
@@ -13,15 +13,15 @@ type GenerateAppInput = {
     description: string;
     preview: boolean;
     requirements?: string;
-    existingFiles?: Array<{ path: string; content: string }>;
+    existingFiles?: Array<{ path: string; contents: string }>;
     editInstruction?: string;
     useBuggyCode?: boolean;
     useFixer?: boolean;
 };
 
 export type GenerateAppResult = {
-    originalFiles?: Array<{ path: string; content: string }>;
-    repairedFiles?: Array<{ path: string; content: string }>;
+    originalFiles?: Array<{ path: string; contents: string }>;
+    repairedFiles?: Array<{ path: string; contents: string }>;
     buildOutput: string;
     previewUrl: string;
     buildErrors?: Array<{
@@ -54,9 +54,9 @@ export async function generateApp(input: GenerateAppInput): Promise<GenerateAppR
             try {
                 console.log("Trying fixer")
                 const fixerResult = await benchify.fixer.run({
-                    files: filesToSandbox.map((file: { path: string; content: string }) => ({
+                    files: filesToSandbox.map((file: { path: string; contents: string }) => ({
                         path: file.path,
-                        contents: file.content
+                        contents: file.contents
                     })),
                     fixes: {
                         stringLiterals: true,
@@ -65,11 +65,8 @@ export async function generateApp(input: GenerateAppInput): Promise<GenerateAppR
 
                 const fixedFiles = (fixerResult as any).data?.suggested_changes?.all_files;
                 if (fixedFiles && Array.isArray(fixedFiles)) {
-                    // Convert from fixer format (contents) to our format (content)
-                    repairedFiles = fixedFiles.map((file: any) => ({
-                        path: file.path,
-                        content: file.contents
-                    }));
+                    // Use the fixer files directly since they already have the correct format
+                    repairedFiles = fixedFiles;
                 }
 
                 console.log('🔧 Benchify fixer data:', repairedFiles);

--- a/lib/e2b.ts
+++ b/lib/e2b.ts
@@ -38,7 +38,7 @@ export async function createSandbox({ files }: { files: z.infer<typeof benchifyF
     // Write files directly to the working directory (/app)
     const filesToWrite = transformedFiles.map(file => ({
         path: `/app/${file.path}`,
-        data: file.content
+        data: file.contents
     }));
 
     await sandbox.files.write(filesToWrite);
@@ -50,7 +50,7 @@ export async function createSandbox({ files }: { files: z.infer<typeof benchifyF
     if (packageJsonFile) {
         console.log('package.json detected, checking for new dependencies...');
         try {
-            const newPackages = extractNewPackages(packageJsonFile.content);
+            const newPackages = extractNewPackages(packageJsonFile.contents);
 
             if (newPackages.length > 0) {
                 console.log('Installing new packages:', newPackages);

--- a/lib/file-filter.ts
+++ b/lib/file-filter.ts
@@ -4,7 +4,7 @@ import { benchifyFileSchema } from './schemas';
 
 export type FileEntry = {
     path: string;
-    content: string;
+    contents: string;
 };
 
 // List of boilerplate files to filter out from results
@@ -116,7 +116,7 @@ async function listFilesRecursively(
                     // Add file to result array with normalized path
                     result.push({
                         path: normalizedPath,
-                        content: contentStr
+                        contents: contentStr
                     });
 
                 } catch (error) {

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -14,13 +14,13 @@ if (!OPENAI_API_KEY) {
 // Schema for a single file
 const fileSchema = z.object({
     path: z.string(),
-    content: z.string()
+    contents: z.string()
 });
 
 // Generate a new application using AI SDK
 export async function createNewApp(
     description: string,
-): Promise<Array<{ path: string; content: string }>> {
+): Promise<Array<{ path: string; contents: string }>> {
     console.log("Creating app with description: ", description);
 
     try {
@@ -71,7 +71,7 @@ export async function editApp(
     editInstruction: string,
 ): Promise<z.infer<typeof benchifyFileSchema>> {
     console.log("Editing app with instruction: ", editInstruction);
-    console.log('Existing files:', existingFiles.map(f => ({ path: f.path, contentLength: f.content.length })));
+    console.log('Existing files:', existingFiles.map(f => ({ path: f.path, contentLength: f.contents.length })));
 
     try {
         const { elementStream } = streamObject({
@@ -94,11 +94,11 @@ export async function editApp(
             throw new Error("Failed to generate updated files - received empty response");
         }
 
-        console.log("Generated updated files: ", updatedFiles.map(f => ({ path: f.path, contentLength: f.content.length })));
+        console.log("Generated updated files: ", updatedFiles.map(f => ({ path: f.path, contentLength: f.contents.length })));
 
         // Merge the updated files with the existing files
         const mergedFiles = mergeFiles(existingFiles, updatedFiles);
-        console.log('Final merged files:', mergedFiles.map(f => ({ path: f.path, contentLength: f.content.length })));
+        console.log('Final merged files:', mergedFiles.map(f => ({ path: f.path, contentLength: f.contents.length })));
 
         return mergedFiles;
     } catch (error) {
@@ -128,7 +128,7 @@ export async function generateAppCode(
             return [
                 {
                     path: "src/App.tsx",
-                    content: `export interface Vehicle {
+                    contents: `export interface Vehicle {
     id: string
     title: string
     price: number

--- a/lib/sandbox-helpers.ts
+++ b/lib/sandbox-helpers.ts
@@ -11,9 +11,9 @@ export const transformations = {
      */
     tailwindSyntax(files: z.infer<typeof benchifyFileSchema>): z.infer<typeof benchifyFileSchema> {
         for (const file of files) {
-            if (file.path.endsWith('.css') && file.content.includes('@tailwind')) {
+            if (file.path.endsWith('.css') && file.contents.includes('@tailwind')) {
                 console.log(`Updating Tailwind v4 syntax in ${file.path}`);
-                file.content = '@import "tailwindcss";';
+                file.contents = '@import "tailwindcss";';
             }
         }
         return files;
@@ -27,21 +27,21 @@ export const transformations = {
         for (const file of files) {
             if (file.path.endsWith('.tsx') || file.path.endsWith('.jsx')) {
                 // Check if file contains ReactDOM.render
-                if (file.content.includes('ReactDOM.render(')) {
+                if (file.contents.includes('ReactDOM.render(')) {
                     console.log(`Updating ReactDOM API in ${file.path}`);
 
                     // Fix the import statement
-                    file.content = file.content.replace(
+                    file.contents = file.contents.replace(
                         "import ReactDOM from 'react-dom';",
                         "import ReactDOM from 'react-dom/client';"
                     );
-                    file.content = file.content.replace(
+                    file.contents = file.contents.replace(
                         'import ReactDOM from "react-dom";',
                         'import ReactDOM from "react-dom/client";'
                     );
 
                     // Fix the render method (basic transformation)
-                    file.content = file.content.replace(
+                    file.contents = file.contents.replace(
                         /ReactDOM\.render\(\s*([\s\S]*?),\s*document\.getElementById\(['"](.*)['"]\)\s*\)/,
                         "ReactDOM.createRoot(document.getElementById('$2') as HTMLElement).render($1)"
                     );

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 // Benchify API schema - matching the exact format in the API docs
 export const benchifyFileSchema = z.array(z.object({
     path: z.string(),
-    content: z.string()
+    contents: z.string()
 }));
 
 export const benchifyRequestSchema = z.object({

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,7 +2,7 @@ import { Process } from '@e2b/sdk';
 
 export interface GeneratedFile {
     path: string;
-    content: string;
+    contents: string;
 }
 
 export interface SandboxFile {


### PR DESCRIPTION
### TL;DR

Standardized file property naming from `content` to `contents` across the codebase to align with Benchify API.

### What changed?

- Renamed the `content` property to `contents` in all file-related interfaces and types
- Updated all references to this property throughout the codebase
- Removed unnecessary type conversions between Benchify API responses and internal data structures
- Added proper type import from Benchify for `FixerRunResponse`
- Made some properties optional in the `FixResult` interface
- Simplified file handling in the fixer and generate-app actions

### How to test?

1. Run the application and create a new chat
2. Test file generation and preview functionality
3. Verify that code editing and fixing works correctly
4. Check that file contents display properly in the code editor

### Why make this change?

This change standardizes our internal data model to match the Benchify API's expected format, which uses `contents` rather than `content`. This eliminates unnecessary property mapping and type conversions, reducing potential bugs and improving code maintainability. The change also properly types the API responses, making the codebase more robust.