### PR TITLE
Update fix with fixer to connect to existing sandbox BEN-1524

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -8,7 +8,7 @@ import { generateApp, GenerateAppResult } from '@/lib/actions/generate-app';
 import { generateSessionId } from '@/lib/progress-tracker';
 
 // Extract the success type from the union
-type GenerationResult = Extract<GenerateAppResult, { buildOutput: string }>;
+type GenerationResult = Extract<GenerateAppResult, { buildOutput: string }> & { sandboxId?: string };
 
 export default function ChatPage() {
     const router = useRouter();
@@ -149,6 +149,7 @@ export default function ChatPage() {
                     hasErrors={result?.hasErrors}
                     onFixComplete={handleUpdateResult}
                     sessionId={sessionId || undefined}
+                    sandboxId={result?.sandboxId}
                 />
             </div>
         </div>

--- a/components/ui-builder/error-display.tsx
+++ b/components/ui-builder/error-display.tsx
@@ -37,9 +37,10 @@ interface ErrorDisplayProps {
     currentFiles?: z.infer<typeof benchifyFileSchema>;
     onFixComplete?: (result: FixResult) => void;
     sessionId?: string;
+    sandboxId?: string; // Add sandbox ID to reuse existing sandbox
 }
 
-export function ErrorDisplay({ errors, currentFiles, onFixComplete, sessionId }: ErrorDisplayProps) {
+export function ErrorDisplay({ errors, currentFiles, onFixComplete, sessionId, sandboxId }: ErrorDisplayProps) {
     const [isFixing, setIsFixing] = useState(false);
     const [isBenchifyFixing, setIsBenchifyFixing] = useState(false);
     const [fixSessionId, setFixSessionId] = useState<string | null>(null);
@@ -208,9 +209,11 @@ Please make the minimal changes necessary to resolve these errors while maintain
 
         try {
             // Run the Benchify fixer on current files
+            console.log('🔄 Running Benchify fixer with sandboxId:', sandboxId);
             const fixResult = await runBenchifyFixer({
                 files: currentFiles,
                 sessionId: newSessionId,
+                existingSandboxId: sandboxId, // Reuse existing sandbox if available
             });
 
             if ('error' in fixResult) {

--- a/components/ui-builder/preview-card.tsx
+++ b/components/ui-builder/preview-card.tsx
@@ -25,6 +25,7 @@ interface FixResult {
     repairedFiles?: z.infer<typeof benchifyFileSchema>;
     buildOutput: string;
     previewUrl: string;
+    sandboxId?: string; // Add sandbox ID to match the fixer result (optional for backwards compatibility)
     buildErrors?: BuildError[];
     hasErrors?: boolean;
     editInstruction?: string;
@@ -39,6 +40,7 @@ interface PreviewCardProps {
     hasErrors?: boolean;
     onFixComplete?: (result: FixResult) => void;
     sessionId?: string;
+    sandboxId?: string; // Add sandbox ID for reusing existing sandbox
 }
 
 export function PreviewCard({
@@ -49,7 +51,8 @@ export function PreviewCard({
     buildErrors = [],
     hasErrors = false,
     onFixComplete,
-    sessionId
+    sessionId,
+    sandboxId
 }: PreviewCardProps) {
     const files = code || [];
     const { progress, isConnected, error: progressError } = useProgress(sessionId || null);
@@ -156,6 +159,7 @@ export function PreviewCard({
                             currentFiles={files}
                             onFixComplete={onFixComplete}
                             sessionId={sessionId}
+                            sandboxId={sandboxId}
                         />
                     ) : previewUrl ? (
                         // Show the actual preview iframe when ready

--- a/lib/actions/benchify-fixer.ts
+++ b/lib/actions/benchify-fixer.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { Benchify } from 'benchify';
-import { createSandbox } from '@/lib/e2b';
+import { createSandbox, updateSandboxFiles } from '@/lib/e2b';
 import { FixerRunResponse } from 'benchify/resources/fixer.mjs';
 import { ProgressTracker } from '@/lib/progress-tracker';
 
@@ -12,6 +12,7 @@ const benchify = new Benchify({
 type BenchifyFixerInput = {
     files: Array<{ path: string; contents: string }>;
     sessionId?: string;
+    existingSandboxId?: string; // Optional: reuse existing sandbox instead of creating new one
 };
 
 export type BenchifyFixerResult = {
@@ -19,6 +20,7 @@ export type BenchifyFixerResult = {
     repairedFiles: Array<{ path: string; contents: string }>;
     buildOutput: string;
     previewUrl: string;
+    sandboxId: string; // Add sandbox ID so it can be reused
     buildErrors?: Array<{
         type: 'typescript' | 'build' | 'runtime';
         message: string;
@@ -35,10 +37,41 @@ export type BenchifyFixerResult = {
 };
 
 export async function runBenchifyFixer(input: BenchifyFixerInput): Promise<BenchifyFixerResult> {
-    const { files, sessionId } = input;
+    const { files, sessionId, existingSandboxId } = input;
 
-    // Define the steps for the fixer process
-    const steps = [
+    // Define the steps for the fixer process (different steps for new vs existing sandbox)
+    const steps = existingSandboxId ? [
+        {
+            id: 'running-fixer',
+            label: 'Running Benchify Fixer',
+            description: 'Analyzing and optimizing code for better performance and quality'
+        },
+        {
+            id: 'updating-files',
+            label: 'Updating Files',
+            description: 'Applying optimized code to your existing sandbox'
+        },
+        {
+            id: 'installing-deps',
+            label: 'Installing Dependencies',
+            description: 'Installing any new required packages'
+        },
+        {
+            id: 'hot-reloading',
+            label: 'Hot Reloading',
+            description: 'Applying changes with hot reload for instant updates'
+        },
+        {
+            id: 'verifying-update',
+            label: 'Verifying Update',
+            description: 'Ensuring the optimized code is working correctly'
+        },
+        {
+            id: 'finalizing-preview',
+            label: 'Finalizing',
+            description: 'Your optimized application is ready!'
+        }
+    ] : [
         {
             id: 'running-fixer',
             label: 'Running Benchify Fixer',
@@ -102,16 +135,32 @@ export async function runBenchifyFixer(input: BenchifyFixerInput): Promise<Bench
 
         progressTracker?.completeStep('running-fixer');
 
-        // Step 2-5: Create sandbox with detailed progress tracking
-        progressTracker?.startStep('creating-sandbox');
-        const sandboxResult = await createSandbox({ files: repairedFiles, progressTracker: progressTracker });
+        // Step 2-5: Create or update sandbox with detailed progress tracking
+        let sandboxResult;
+        if (existingSandboxId) {
+            // Update existing sandbox with optimized files
+            console.log(`🔄 Updating existing sandbox: ${existingSandboxId}`);
+            sandboxResult = await updateSandboxFiles({
+                sandboxId: existingSandboxId,
+                files: repairedFiles,
+                progressTracker: progressTracker
+            });
+        } else {
+            // Create new sandbox
+            console.log('🆕 Creating new sandbox');
+            progressTracker?.startStep('creating-sandbox');
+            sandboxResult = await createSandbox({ files: repairedFiles, progressTracker: progressTracker });
+        }
 
         // Return the results in the same format as generate-app
         return {
             originalFiles: files,
             repairedFiles: sandboxResult.allFiles,
-            buildOutput: `Sandbox created with template: ${sandboxResult.template}, ID: ${sandboxResult.sbxId}`,
+            buildOutput: existingSandboxId
+                ? `Sandbox updated with optimized code, ID: ${sandboxResult.sbxId}`
+                : `Sandbox created with template: ${sandboxResult.template}, ID: ${sandboxResult.sbxId}`,
             previewUrl: sandboxResult.url,
+            sandboxId: sandboxResult.sbxId,
             buildErrors: sandboxResult.buildErrors,
             hasErrors: sandboxResult.hasErrors,
             sessionId,

--- a/lib/actions/generate-app.ts
+++ b/lib/actions/generate-app.ts
@@ -26,6 +26,7 @@ export type GenerateAppResult = {
     repairedFiles?: Array<{ path: string; contents: string }>;
     buildOutput: string;
     previewUrl: string;
+    sandboxId?: string;
     buildErrors?: Array<{
         type: 'typescript' | 'build' | 'runtime';
         message: string;
@@ -143,6 +144,7 @@ export async function generateApp(input: GenerateAppInput): Promise<GenerateAppR
             repairedFiles: sandboxResult.allFiles,
             buildOutput: `Sandbox created with template: ${sandboxResult.template}, ID: ${sandboxResult.sbxId}`,
             previewUrl: sandboxResult.url,
+            sandboxId: sandboxResult.sbxId,
             buildErrors: sandboxResult.buildErrors,
             hasErrors: sandboxResult.hasErrors,
             sessionId,


### PR DESCRIPTION
### TL;DR

Added sandbox reuse functionality to improve error fixing performance by updating existing sandboxes instead of creating new ones for each fix.

### What changed?

- Added `sandboxId` property to various interfaces to track and reuse existing sandboxes
- Created new `updateSandboxFiles` function in `lib/e2b.ts` to update files in an existing sandbox
- Modified `runBenchifyFixer` to accept an optional `existingSandboxId` parameter
- Updated progress tracking steps to reflect different workflows for new vs. existing sandboxes
- Propagated the `sandboxId` through components to enable sandbox reuse during error fixing

### How to test?

1. Generate an app with errors in the chat interface
2. Click "Fix Errors" button
3. Verify that subsequent error fixes reuse the same sandbox (check console logs for "Updating existing sandbox" message)
4. Confirm that error fixes are applied more quickly than before
5. Verify that the preview updates correctly after each fix

### Why make this change?

Creating a new sandbox for each error fix is time-consuming and inefficient. By reusing existing sandboxes and applying hot reloading, we can significantly improve the performance of the error fixing process, providing a better developer experience with faster feedback cycles.