### PR TITLE
Update fix with AI to connect to existing sandbox BEN-1525

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -135,6 +135,7 @@ export default function ChatPage() {
                     currentFiles={result?.repairedFiles || result?.originalFiles}
                     onUpdateResult={handleUpdateResult}
                     sessionId={sessionId || undefined}
+                    sandboxId={result?.sandboxId}
                 />
             </div>
 

--- a/components/ui-builder/chat-interface.tsx
+++ b/components/ui-builder/chat-interface.tsx
@@ -25,6 +25,7 @@ interface ChatInterfaceProps {
         originalFiles?: z.infer<typeof benchifyFileSchema>;
         buildOutput: string;
         previewUrl: string;
+        sandboxId?: string;
         buildErrors?: Array<{
             type: 'typescript' | 'build' | 'runtime';
             message: string;
@@ -35,9 +36,10 @@ interface ChatInterfaceProps {
         hasErrors?: boolean;
     }) => void;
     sessionId?: string;
+    sandboxId?: string; // Add sandbox ID for reusing existing sandbox
 }
 
-export function ChatInterface({ initialPrompt, currentFiles, onUpdateResult, sessionId }: ChatInterfaceProps) {
+export function ChatInterface({ initialPrompt, currentFiles, onUpdateResult, sessionId, sandboxId }: ChatInterfaceProps) {
     const [messages, setMessages] = useState<Message[]>([
         {
             id: '1',
@@ -94,6 +96,7 @@ export function ChatInterface({ initialPrompt, currentFiles, onUpdateResult, ses
             const useFixer = sessionStorage.getItem('useFixer') === 'true';
 
             // Call the server action
+            console.log('🔄 Running chat edit with sandboxId:', sandboxId);
             const editResult = await generateApp({
                 type: 'component',
                 description: '', // Not used for edits
@@ -103,6 +106,7 @@ export function ChatInterface({ initialPrompt, currentFiles, onUpdateResult, ses
                 useBuggyCode,
                 useFixer,
                 sessionId: sessionId,
+                existingSandboxId: sandboxId, // Reuse existing sandbox if available
             });
 
             console.log('Edit request:', {

--- a/components/ui-builder/error-display.tsx
+++ b/components/ui-builder/error-display.tsx
@@ -171,6 +171,7 @@ Please make the minimal changes necessary to resolve these errors while maintain
             const useFixer = sessionStorage.getItem('useFixer') === 'true';
 
             // Use the server action
+            console.log('🔄 Running AI fix with sandboxId:', sandboxId);
             const fixResult = await generateApp({
                 type: 'component',
                 description: '',
@@ -180,6 +181,7 @@ Please make the minimal changes necessary to resolve these errors while maintain
                 useBuggyCode,
                 useFixer,
                 sessionId: newSessionId,
+                existingSandboxId: sandboxId, // Reuse existing sandbox if available
             });
 
             if ('error' in fixResult) {


### PR DESCRIPTION
### TL;DR

Added sandbox reuse functionality to improve performance and maintain state between edits.

### What changed?

- Added support for reusing existing sandboxes when making edits or fixing errors
- Passed `sandboxId` through the component hierarchy from the chat page to the chat interface
- Modified the `generateApp` function to accept an `existingSandboxId` parameter
- Added a new `updateSandboxFiles` flow path when an existing sandbox ID is provided
- Updated progress tracking steps to reflect different workflows for new vs. existing sandboxes
- Added logging to track sandbox reuse

### How to test?

1. Open the chat interface and generate an initial component
2. Make an edit or fix an error in the same session
3. Check console logs to verify the sandbox ID is being reused
4. Verify that state is maintained between edits (e.g., component state, dependencies)
5. Confirm that the UI updates correctly after edits with the reused sandbox

### Why make this change?

Reusing sandboxes between edits provides several benefits:
- Faster iteration cycles since we don't need to recreate the entire environment
- Preservation of state between edits (installed dependencies, environment setup)
- Reduced resource usage by avoiding unnecessary sandbox creation
- Better developer experience with quicker feedback loops during iterative development