### PR TITLE
Add generating patch state BEN-1549

### DIFF
--- a/lib/actions/generate-app.ts
+++ b/lib/actions/generate-app.ts
@@ -47,12 +47,17 @@ export type GenerateAppResult = {
 export async function generateApp(input: GenerateAppInput): Promise<GenerateAppResult> {
     const { description, existingFiles, editInstruction, useBuggyCode, useFixer, sessionId, existingSandboxId } = input;
 
-    // Define the actual steps that will happen (different for new vs existing sandbox)
+    // Detect if this is a repair operation (fixing build errors)
+    const isRepairMode = existingSandboxId && editInstruction && editInstruction.includes('Fix the following build errors');
+
+    // Define the actual steps that will happen (different for new vs existing vs repair)
     const steps = existingSandboxId ? [
         {
             id: 'generating-code',
-            label: 'Generating Code',
-            description: 'Creating components and functionality with AI assistance'
+            label: isRepairMode ? 'Generating Patch' : 'Generating Code',
+            description: isRepairMode
+                ? 'Attempting to generate patch with AI to fix build errors'
+                : 'Creating components and functionality with AI assistance'
         },
         ...(useFixer ? [{
             id: 'fixing-code',


### PR DESCRIPTION
### TL;DR

Added specialized UI messaging for repair operations when fixing build errors.

### What changed?

- Added detection for "repair mode" by checking if the edit instruction includes "Fix the following build errors"
- Updated the step label to show "Generating Patch" instead of "Generating Code" when in repair mode
- Updated the step description to be more specific about fixing build errors when in repair mode

### How to test?

1. Create a sandbox with build errors
2. Attempt to fix the build errors using AI assistance
3. Verify that the progress indicator shows "Generating Patch" instead of "Generating Code"
4. Confirm the description mentions "Attempting to generate patch with AI to fix build errors"

### Why make this change?

To provide more accurate and contextual UI feedback to users when the AI is specifically working on fixing build errors rather than generating new code. This helps set appropriate expectations about what the system is doing.